### PR TITLE
Install missing packages and fix pip requirement

### DIFF
--- a/test-server/Dockerfile
+++ b/test-server/Dockerfile
@@ -2,6 +2,9 @@ FROM jkarlos/git-server-docker
 
 # https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md
 RUN apk add --no-cache \
+  libxslt-dev \
+  libxml2-dev \
+  libgit2-dev \
   curl \
   python \
   python-dev \

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -1,3 +1,3 @@
-pygit2
+pygit2==0.24.2
 lxml
 requests


### PR DESCRIPTION
- Installed missing libraries;
- Downgrade pygit to version 0.24.2 because it must have the same
  version as the libgit2 installed.

closes #1